### PR TITLE
Parse designators from TLE and display them on the satellite information box

### DIFF
--- a/src/astro.c
+++ b/src/astro.c
@@ -206,6 +206,11 @@ void load_tle_data(const char *filename)
             line1[strcspn(line1, "\r\n")] = 0;
             line2[strcspn(line2, "\r\n")] = 0;
 
+            memset(&sat->norad_id, 0, sizeof(sat->norad_id));
+            memset(&sat->intl_designator, 0, sizeof(sat->intl_designator));
+            strncpy(sat->norad_id, line1 + 2, sizeof(sat->norad_id));
+            strncpy(sat->intl_designator, line1 + 9, sizeof(sat->intl_designator));
+
             char combined[768];
             snprintf(combined, sizeof(combined), "%s\n%s\n%s\n", line0, line1, line2);
 

--- a/src/types.h
+++ b/src/types.h
@@ -22,6 +22,8 @@
 typedef struct
 {
     char name[32];
+    char norad_id[6];
+    char intl_designator[8];
     double epoch_days;
     double epoch_unix;
     double inclination;

--- a/src/ui.c
+++ b/src/ui.c
@@ -1057,8 +1057,12 @@ void DrawGUI(UIContext *ctx, AppConfig *cfg, Font customFont)
         DrawRectangleLinesEx(bgRec, 1.0f, cfg->ui_secondary);
         Color titleColor = (ctx->active_sat == ctx->hovered_sat) ? cfg->sat_highlighted : cfg->sat_selected;
 
+        char sat_id_line[16]; /* 00900U 64063C */
+        snprintf(sat_id_line, sizeof(sat_id_line), "%.6s %.8s", ctx->active_sat->norad_id, ctx->active_sat->intl_designator);
+
         DrawUIText(customFont, ctx->active_sat->name, boxX + padX, boxY + (10.0f * cfg->ui_scale), titleFontSize, titleColor);
-        DrawUIText(customFont, info, boxX + padX, boxY + (38.0f * cfg->ui_scale), infoFontSize, cfg->text_main);
+        DrawUIText(customFont, sat_id_line, boxX + padX, boxY + (28.0f * cfg->ui_scale), infoFontSize, cfg->text_main);
+        DrawUIText(customFont, info, boxX + padX, boxY + (48.0f * cfg->ui_scale), infoFontSize, cfg->text_main);
 
         Vector2 periScreen, apoScreen;
         bool show_peri = true, show_apo = true;


### PR DESCRIPTION
Parsing was done according to the format shown on [Wikipedia](https://en.wikipedia.org/wiki/File:Tle_first_row.jpg)