### PR TITLE
Updated package names and fixed Arch Linux update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ make linux      # Results in dist/TLEscope-Linux/
 ```
 **Arch-based systems**
 ```
-sudo pacman -Syu
+sudo pacman -Syy
 sudo pacman -S --needed base-devel git alsa-lib libx11 libxrandr libxi mesa glu libxcursor libxinerama wayland libxkbcommon curl
 # If cross-compiling for Windows:
 sudo pacman -S mingw-w64-gcc

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ make linux      # Results in dist/TLEscope-Linux/
 **Arch-based systems**
 ```
 sudo pacman -Syu
-sudo pacman -S --needed base-devel git alsa-lib libx11 libxrandr libxi mesa libglu libxcursor libxinerama wayland libxkbcommon curl
+sudo pacman -S --needed base-devel git alsa-lib libx11 libxrandr libxi mesa glu libxcursor libxinerama wayland libxkbcommon curl
 # If cross-compiling for Windows:
 sudo pacman -S mingw-w64-gcc
 


### PR DESCRIPTION
049a585: -Syu does also an upgrade. Based on the Debian/Ubuntu install command, it seems we only need to update the database rather than doing also an upgrade (e.g. full upgrade).