### PR TITLE
Fix window drag lag (frame trailing content by 1 frame)

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -1649,6 +1649,7 @@ void DrawGUI(UIContext *ctx, AppConfig *cfg, Font customFont)
                 tm_y = GetMousePosition().y - drag_tle_mgr_off.y;
                 SnapWindow(&tm_x, &tm_y, tmMgrWindow.width, tmMgrWindow.height, cfg);
             }
+            tmMgrWindow.x = tm_x; tmMgrWindow.y = tm_y;
             if (DrawMaterialWindow(tmMgrWindow, "#1# TLE Manager", cfg, customFont))
                 show_tle_mgr_dialog = false;
 
@@ -1882,6 +1883,7 @@ void DrawGUI(UIContext *ctx, AppConfig *cfg, Font customFont)
                 sm_y = GetMousePosition().y - drag_sat_mgr_off.y;
                 SnapWindow(&sm_x, &sm_y, smWindow.width, smWindow.height, cfg);
             }
+            smWindow.x = sm_x; smWindow.y = sm_y;
             if (DrawMaterialWindow(smWindow, "#43# Satellite Manager", cfg, customFont))
                 show_sat_mgr_dialog = false;
 
@@ -2012,6 +2014,7 @@ void DrawGUI(UIContext *ctx, AppConfig *cfg, Font customFont)
                 hw_y = GetMousePosition().y - drag_help_off.y;
                 SnapWindow(&hw_x, &hw_y, helpWindow.width, helpWindow.height, cfg);
             }
+            helpWindow.x = hw_x; helpWindow.y = hw_y;
             if (DrawMaterialWindow(helpWindow, "#193# Help & Controls", cfg, customFont))
                 show_help = false;
 
@@ -2129,6 +2132,7 @@ void DrawGUI(UIContext *ctx, AppConfig *cfg, Font customFont)
                 sw_y = GetMousePosition().y - drag_settings_off.y;
                 SnapWindow(&sw_x, &sw_y, settingsWindow.width, settingsWindow.height, cfg);
             }
+            settingsWindow.x = sw_x; settingsWindow.y = sw_y;
             if (DrawMaterialWindow(settingsWindow, "#142# Settings", cfg, customFont))
                 show_settings = false;
 
@@ -2251,6 +2255,7 @@ void DrawGUI(UIContext *ctx, AppConfig *cfg, Font customFont)
                 td_y = GetMousePosition().y - drag_time_off.y;
                 SnapWindow(&td_x, &td_y, timeWindow.width, timeWindow.height, cfg);
             }
+            timeWindow.x = td_x; timeWindow.y = td_y;
             if (DrawMaterialWindow(timeWindow, "#139# Set Date & Time (UTC)", cfg, customFont))
                 show_time_dialog = false;
 
@@ -2317,6 +2322,7 @@ void DrawGUI(UIContext *ctx, AppConfig *cfg, Font customFont)
                 pd_y = GetMousePosition().y - drag_passes_off.y;
                 SnapWindow(&pd_x, &pd_y, passesWindow.width, passesWindow.height, cfg);
             }
+            passesWindow.x = pd_x; passesWindow.y = pd_y;
             if (DrawMaterialWindow(passesWindow, "#208# Upcoming Passes", cfg, customFont))
                 show_passes_dialog = false;
 
@@ -2449,6 +2455,7 @@ void DrawGUI(UIContext *ctx, AppConfig *cfg, Font customFont)
                 pl_y = GetMousePosition().y - drag_polar_off.y;
                 SnapWindow(&pl_x, &pl_y, polarWindow.width, polarWindow.height, cfg);
             }
+            polarWindow.x = pl_x; polarWindow.y = pl_y;
             if (DrawMaterialWindow(polarWindow, "#64# Polar Tracking Plot", cfg, customFont))
                 show_polar_dialog = false;
 
@@ -2639,6 +2646,7 @@ void DrawGUI(UIContext *ctx, AppConfig *cfg, Font customFont)
                 dop_y = GetMousePosition().y - drag_doppler_off.y;
                 SnapWindow(&dop_x, &dop_y, dopplerWindow.width, dopplerWindow.height, cfg);
             }
+            dopplerWindow.x = dop_x; dopplerWindow.y = dop_y;
             if (DrawMaterialWindow(dopplerWindow, "#125# Doppler Shift Analysis", cfg, customFont))
                 show_doppler_dialog = false;
 
@@ -2790,6 +2798,7 @@ case WND_SCOPE:
                 sc_y = GetMousePosition().y - drag_scope_off.y;
                 SnapWindow(&sc_x, &sc_y, scopeWindow.width, scopeWindow.height, cfg);
             }
+            scopeWindow.x = sc_x; scopeWindow.y = sc_y;
             if (DrawMaterialWindow(scopeWindow, "#103# Satellite Scope", cfg, customFont))
                 show_scope_dialog = false;
 
@@ -3128,6 +3137,7 @@ case WND_SCOPE:
                 si_y = GetMousePosition().y - drag_sat_info_off.y;
                 SnapWindow(&si_x, &si_y, satInfoWindow.width, satInfoWindow.height, cfg);
             }
+            satInfoWindow.x = si_x; satInfoWindow.y = si_y;
             if (DrawMaterialWindow(satInfoWindow, TextFormat("#11# %s", (*ctx->selected_sat)->name), cfg, customFont))
             {
                 show_sat_info_dialog = false;


### PR DESCRIPTION
Window Rectangle structs were snapshot copies created at the start of DrawGUI, but drag updates modified the position variables without syncing back to the Rectangle. This caused the frame to draw at the old position while content used the new one. Sync Rectangle position after drag update for all 10 draggable windows.