### PR TITLE
Fix transparent gaps in rounded window corners

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -1042,12 +1042,12 @@ static bool DrawMaterialWindow(Rectangle bounds, const char *title, AppConfig *c
     float scale = cfg->ui_scale;
     float header_h = 24 * scale;
 
-    DrawRectangleRounded(bounds, 0.05f, 16, cfg->ui_primary);
+    DrawRectangleRounded(bounds, 0.05f, 4, cfg->ui_primary);
 
 #if (defined(_WIN32) || defined(_WIN64)) && !defined(_M_ARM64)
-    DrawRectangleRoundedLines(bounds, 0.05f, 16, 1.5f * scale, cfg->window_border);
+    DrawRectangleRoundedLines(bounds, 0.05f, 8, 1.5f * scale, cfg->window_border);
 #else
-    DrawRectangleRoundedLines(bounds, 0.05f, 16, cfg->window_border);
+    DrawRectangleRoundedLines(bounds, 0.05f, 8, cfg->window_border);
 #endif
 
     const char *titleText = title;


### PR DESCRIPTION
Reduce fill segments from 16 to 4 to eliminate sub-pixel gaps in the triangle fan at low roundness. Reduce border segments from 16 to 8 to match.

| Before | After |
|--------|-------|
| <img width="553" height="502" alt="image" src="https://github.com/user-attachments/assets/9705f13b-78ec-47f7-8652-ba5bf0343948" /> | <img width="571" height="511" alt="image" src="https://github.com/user-attachments/assets/b0636b39-8e77-441f-9361-df6c84f25fe6" /> |




