### PR TITLE
Fix scrollbar and scroll panel padding not scaling with ui_scale

### DIFF
--- a/lib/raygui.h
+++ b/lib/raygui.h
@@ -1921,11 +1921,13 @@ int GuiScrollPanel(Rectangle bounds, const char *text, Rectangle content, Vector
     else scrollPos.y = 0.0f;
 
     // Draw detail corner rectangle if both scroll bars are visible
-    if (hasHorizontalScrollBar && hasVerticalScrollBar)
-    {
-        Rectangle corner = { (GuiGetStyle(LISTVIEW, SCROLLBAR_SIDE) == SCROLLBAR_LEFT_SIDE)? (bounds.x + GuiGetStyle(DEFAULT, BORDER_WIDTH) + 2) : (horizontalScrollBar.x + horizontalScrollBar.width + 2), verticalScrollBar.y + verticalScrollBar.height + 2, (float)horizontalScrollBarWidth - 4, (float)verticalScrollBarWidth - 4 };
-        GuiDrawRectangle(corner, 0, BLANK, GetColor(GuiGetStyle(LISTVIEW, TEXT + (state*3))));
-    }
+    // NOTE: disabled — panel background already covers this area, and the original color
+    // (TEXT) didn't match the scrollbar track, causing a visible artifact
+    //if (hasHorizontalScrollBar && hasVerticalScrollBar)
+    //{
+    //    Rectangle corner = { (GuiGetStyle(LISTVIEW, SCROLLBAR_SIDE) == SCROLLBAR_LEFT_SIDE)? (bounds.x + GuiGetStyle(DEFAULT, BORDER_WIDTH) + 2) : (horizontalScrollBar.x + horizontalScrollBar.width + 2), verticalScrollBar.y + verticalScrollBar.height + 2, (float)horizontalScrollBarWidth - 4, (float)verticalScrollBarWidth - 4 };
+    //    GuiDrawRectangle(corner, 0, BLANK, GetColor(GuiGetStyle(LISTVIEW, TEXT + (state*3))));
+    //}
 
     // Draw scrollbar lines depending on current state
     GuiDrawRectangle(bounds, GuiGetStyle(DEFAULT, BORDER_WIDTH), GetColor(GuiGetStyle(LISTVIEW, BORDER + (state*3))), BLANK);

--- a/lib/raygui.h
+++ b/lib/raygui.h
@@ -1809,8 +1809,9 @@ int GuiScrollPanel(Rectangle bounds, const char *text, Rectangle content, Vector
     int horizontalScrollBarWidth = hasHorizontalScrollBar? GuiGetStyle(LISTVIEW, SCROLLBAR_WIDTH) : 0;
     int verticalScrollBarWidth =  hasVerticalScrollBar? GuiGetStyle(LISTVIEW, SCROLLBAR_WIDTH) : 0;
 
-    float padCorner = 6.0f; // padding to prevent scrollbars and text from clipping over rounded corners
-    float padEdge = 2.0f;
+    float guiScale = (float)GuiGetStyle(DEFAULT, TEXT_SIZE) / 10.0f; // derive scale from text size (default 10)
+    float padCorner = 6.0f * guiScale;
+    float padEdge = 2.0f * guiScale;
 
     Rectangle horizontalScrollBar = { 
         (float)((GuiGetStyle(LISTVIEW, SCROLLBAR_SIDE) == SCROLLBAR_LEFT_SIDE)? (float)bounds.x + verticalScrollBarWidth : (float)bounds.x) + GuiGetStyle(DEFAULT, BORDER_WIDTH) + padCorner, 

--- a/src/ui.c
+++ b/src/ui.c
@@ -1386,6 +1386,12 @@ void DrawGUI(UIContext *ctx, AppConfig *cfg, Font customFont)
 
     GuiSetStyle(CHECKBOX, TEXT_PADDING, 8 * cfg->ui_scale);
 
+    GuiSetStyle(LISTVIEW, SCROLLBAR_WIDTH, 12 * cfg->ui_scale);
+    GuiSetStyle(LISTVIEW, LIST_ITEMS_HEIGHT, 28 * cfg->ui_scale);
+    GuiSetStyle(SCROLLBAR, SCROLL_SLIDER_SIZE, 16 * cfg->ui_scale);
+    GuiSetStyle(SCROLLBAR, ARROWS_SIZE, 6 * cfg->ui_scale);
+    GuiSetStyle(SCROLLBAR, SCROLL_SPEED, 12 * cfg->ui_scale);
+
     GuiSetStyle(TEXTBOX, BORDER_COLOR_FOCUSED, ColorToInt(cfg->window_border_focus));
     GuiSetStyle(TEXTBOX, BORDER_COLOR_PRESSED, ColorToInt(cfg->window_border_focus));
     GuiSetStyle(TEXTBOX, TEXT_COLOR_FOCUSED, ColorToInt(cfg->text_main));


### PR DESCRIPTION
Scrollbar width, slider size, arrow size, scroll speed, and list item height were using raygui's hardcoded defaults (12px, 16px, etc.) regardless of ui_scale. Set them scaled in the style setup.

Also fix scroll panel corner/edge padding in raygui which was hardcoded at 6px/2px. Derive scale from text size ratio since raygui has no dedicated scale property.

<img width="229" height="273" alt="image" src="https://github.com/user-attachments/assets/d2393102-0a47-4a49-a433-edb4cd7106b5" />

<img width="223" height="285" alt="image" src="https://github.com/user-attachments/assets/dbab3442-aac8-45cb-b8e7-ace8a8f99bca" />
