### PR TITLE
New path stuff for package distribuition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ dist/
 
 # csv exports
 *.csv
+
+# ignore CLANGD cache
+.cache

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ else
 	LIB_WIN_PATH = -Ilib/raylib_win/include -Llib/raylib_win/lib -I$(MINGW_PREFIX)/include -L$(MINGW_PREFIX)/lib
 endif
 
+ifdef BUILD_FOR_DIST
+	CFLAGS += -DBUILD_FOR_DIST
+endif
+
 LIB_LIN_PATH = -Ilib/raylib_lin/include -Llib/raylib_lin/lib
 
 SRC       = src/main.c src/astro.c src/config.c src/ui.c src/rotator.c
@@ -47,6 +51,9 @@ DIST_MACOS = dist/TLEscope-macOS-Portable
 all: linux
 
 linux: bin/TLEscope
+ifeq ($(BUILD_FOR_DIST),yes)
+	@echo "Skipping bundling for distribution build (BUILD_FOR_DIST=yes) the binary can be found in bin."
+else
 	@mkdir -p $(DIST_LINUX)
 	cp bin/TLEscope $(DIST_LINUX)/
 	cp -r themes/ $(DIST_LINUX)/
@@ -55,6 +62,7 @@ linux: bin/TLEscope
 	cp logo*.png $(DIST_LINUX)/ 2>/dev/null || true
 	@echo "Linux build bundled in $(DIST_LINUX)/, do not run bin/*"
 	@echo "Here's your subshell command to run it! (cd $(DIST_LINUX)/ && ./TLEscope)"
+endif
 
 macos: bin/TLEscope-macos
 	@mkdir -p $(DIST_MACOS)

--- a/src/astro.c
+++ b/src/astro.c
@@ -217,9 +217,24 @@ bool add_satellite_from_tle(const char* line0, const char* line1, const char* li
 }
 
 /* bulk loading of celestial junk from flat files */
-void load_tle_data(const char *filename)
+void load_tle_data(const char *tlefile)
 {
-    FILE *file = fopen(filename, "r");
+    char filename[1024];
+
+    #if defined (BUILD_FOR_DIST)
+    //The full path, with /<the tle file> at the end
+    char fullPath[1024];
+    const char *homeDir = getenv("XDG_CONFIG_HOME");
+    if (!homeDir) homeDir = getenv("HOME");
+    snprintf(fullPath,sizeof(fullPath),"%s/.config/TLEscope/%s", homeDir,tlefile);
+    
+    printf("DEBUG: %s\n", fullPath);
+    snprintf(filename,sizeof(filename),fullPath);
+    #else 
+    snprintf(filename, sizeof(filename),tlefile);
+    #endif
+
+    FILE *file = fopen(filename, "r"); 
     if (!file)
     {
         printf("Failed to open %s\n", filename);

--- a/src/config.c
+++ b/src/config.c
@@ -509,7 +509,7 @@ void LoadAppConfig(const char *resource, AppConfig *config)
             UnloadFileText(theme_text);
         }
     }else {
-        printf("ERROR: Theme files not found!");
+        printf("ERROR: Theme files could not be found!\n");
     }
 }
 
@@ -529,10 +529,10 @@ void SaveAppConfig(const char *resource, AppConfig *config)
     snprintf(filename, sizeof(filename),resource);
     #endif
     
-    printf("THERE IS THE PATH WE SAVIN AT %s",filename);
+    printf("Saving config to %s \n",filename);
     FILE *file = fopen(filename, "w");
     if (!file){
-        printf("SOMEHOW THE PATH IS WRONG SHITHEAD %s",filename);
+        printf("ERROR couldn't open path: %s \n",filename);
         return;
     }
     fprintf(file, "{\n");

--- a/src/config.c
+++ b/src/config.c
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+
+
 Marker home_location;
 
 // turn hex strings into real colors
@@ -29,7 +31,7 @@ Color ParseHexColor(const char *hexStr, Color fallback)
 }
 
 // read the json file and grab our settings
-void LoadAppConfig(const char *filename, AppConfig *config)
+void LoadAppConfig(const char *resource, AppConfig *config)
 {
     // default theme configuration
     strcpy(config->theme, "default");
@@ -42,6 +44,22 @@ void LoadAppConfig(const char *filename, AppConfig *config)
     config->show_first_run_dialog = false; //default
     config->hint_vsync = true;       // default
     config->custom_tle_source_count = 0;
+    
+    
+    char filename[1024];
+
+    #if defined (BUILD_FOR_DIST)
+    //The full path, with /settings.json at the end
+    char fullPath[1024];
+    const char *homeDir = getenv("XDG_CONFIG_HOME");
+    if (!homeDir) homeDir = getenv("HOME");
+    snprintf(fullPath,sizeof(fullPath),"%s/.config/TLEscope/%s", homeDir,resource);
+    
+    printf("DEBUG: %s\n", fullPath);
+    snprintf(filename,sizeof(filename),fullPath);
+    #else 
+    snprintf(filename, sizeof(filename),resource);
+    #endif
 
     if (FileExists(filename))
     {
@@ -435,8 +453,11 @@ void LoadAppConfig(const char *filename, AppConfig *config)
 
     // load colors from the selected theme file
     char theme_path[256];
+    #if defined (BUILD_FOR_DIST)
+    snprintf(theme_path, sizeof(theme_path), "/usr/share/TLEscope/themes/%s/theme.json", config->theme);
+    #else
     snprintf(theme_path, sizeof(theme_path), "themes/%s/theme.json", config->theme);
-
+    #endif
     if (FileExists(theme_path))
     {
         char *theme_text = LoadFileText(theme_path);
@@ -487,15 +508,33 @@ void LoadAppConfig(const char *filename, AppConfig *config)
 
             UnloadFileText(theme_text);
         }
+    }else {
+        printf("ERROR: Theme files not found!");
     }
 }
 
-void SaveAppConfig(const char *filename, AppConfig *config)
+void SaveAppConfig(const char *resource, AppConfig *config)
 {
-    FILE *file = fopen(filename, "w");
-    if (!file)
-        return;
+    char filename[1024];
 
+    #if defined (BUILD_FOR_DIST)
+    //The full path, with /settings.json at the end
+    char fullPath[1024];
+    const char *homeDir = getenv("HOME");
+    snprintf(fullPath,sizeof(fullPath),"%s/.config/TLEscope/%s", homeDir,resource);
+    
+    printf("DEBUG: %s\n", fullPath);
+    snprintf(filename,sizeof(filename),fullPath);
+    #else 
+    snprintf(filename, sizeof(filename),resource);
+    #endif
+    
+    printf("THERE IS THE PATH WE SAVIN AT %s",filename);
+    FILE *file = fopen(filename, "w");
+    if (!file){
+        printf("SOMEHOW THE PATH IS WRONG SHITHEAD %s",filename);
+        return;
+    }
     fprintf(file, "{\n");
     fprintf(file, "    \"theme\": \"%s\",\n", config->theme);
     fprintf(file, "    \"window_width\": %d,\n", config->window_width);
@@ -513,7 +552,7 @@ void SaveAppConfig(const char *filename, AppConfig *config)
     fprintf(file, "    \"show_scattering\": %s,\n", config->show_scattering ? "true" : "false");
     fprintf(file, "    \"show_skybox\": %s,\n", config->show_skybox ? "true" : "false");
     fprintf(file, "    \"hint_vsync\": %s,\n", config->hint_vsync ? "true" : "false");
-    fprintf(file, "    \"show_first_run_dialog\": %s,\n", config->show_first_run_dialog ? "true" : "false");
+    
 
     if (config->custom_tle_source_count > 0)
     {

--- a/src/main.c
+++ b/src/main.c
@@ -10,12 +10,27 @@
 #include "astro.h"
 #include "config.h"
 
+const char* get_resource_path(const char* resource) {  
+    static char fullPath[512];
+    #if defined (BUILD_FOR_DIST)
+    snprintf(fullPath, sizeof(fullPath), "/usr/share/TLEscope/%s", resource);
+    if (FileExists(fullPath)) {
+        return fullPath;
+    } else {
+        printf("ERROR: resource file was not found at %s, trying fallabck path\n",fullPath);
+        return resource;
+    }
+    #else
+    return resource;
+    #endif
+}
+
 static const char* GetAssetPath(const char* theme, const char* filename) {
     static char path[256];
     snprintf(path, sizeof(path), "themes/%s/%s", theme, filename);
     if (FileExists(path)) return path;
     snprintf(path, sizeof(path), "themes/default/%s", filename);
-    return path;
+    return get_resource_path(path);
 }
 #include "types.h"
 #include "ui.h"
@@ -494,22 +509,7 @@ static bool GetMouseEarthIntersection(Vector2 mouse, bool is_2d, Camera2D cam2d,
     }
 }
 
-const char* get_resource_path(const char* resource) {  
-    static char fullPath[512];
-    #if defined (BUILD_FOR_DIST)
-    snprintf(fullPath, sizeof(fullPath), "/usr/share/TLEscope/%s", resource);
-    if (FileExists(fullPath)) {
-        return fullPath;
-    } else {
-        printf("ERROR: resource file was not found at %s, trying fallabck path\n",fullPath);
-        return resource;
-    }
-    #else
-    return resource;
-    #endif
 
-
-}
 
 int main(void)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 #include "astro.h"
 #include "config.h"
@@ -493,10 +494,51 @@ static bool GetMouseEarthIntersection(Vector2 mouse, bool is_2d, Camera2D cam2d,
     }
 }
 
+const char* get_resource_path(const char* resource) {  
+    static char fullPath[512];
+    #if defined (BUILD_FOR_DIST)
+    snprintf(fullPath, sizeof(fullPath), "/usr/share/TLEscope/%s", resource);
+    if (FileExists(fullPath)) {
+        return fullPath;
+    } else {
+        printf("ERROR: resource file was not found at %s, trying fallabck path\n",fullPath);
+        return resource;
+    }
+    #else
+    return resource;
+    #endif
+
+
+}
+
 int main(void)
 {
-    LoadAppConfig("settings.json", &cfg);
+    
+    #if defined(BUILD_FOR_DIST)
+    //The path to the user's .config/TLEscope. Can we expect a path longer than this?? I sure hope not :omba:
+    char configPath[1024];
 
+    const char *homeDir = getenv("HOME");
+    if (!homeDir) {
+        printf("The $HOME env variable is not set. Exiting\n");
+        return 1; 
+    }
+    snprintf(configPath,sizeof(configPath),"%s/.config/TLEscope", homeDir);
+
+    if (!DirectoryExists(configPath)) {
+        //if the config directory is missing in the user's home directory, create it.
+        printf("creating config directory, as it didn't exist before at %s \n",configPath);
+        int status = mkdir(configPath,S_IRWXU);
+        if ( status !=0 ) {
+            // Maybe print the meaning of the error code, not just th code itself?
+            printf("The config directory couldn't be created, with error code %i. Exiting\n",status);
+            return 1;
+        }
+    }
+
+    #endif
+    LoadAppConfig("settings.json", &cfg);
+    
     /* window setup and msaa */
     SetConfigFlags(FLAG_MSAA_4X_HINT | FLAG_WINDOW_RESIZABLE);
 
@@ -535,7 +577,7 @@ int main(void)
     SetExitKey(0);
 
     /* logo and icon loading */
-    Image logoImg = LoadImage("logo.png");
+    Image logoImg = LoadImage(get_resource_path("logo.png")); //DONE
     Texture2D logoTex = {0};
     if (logoImg.data != NULL)
     {
@@ -543,7 +585,7 @@ int main(void)
         logoTex = LoadTextureFromImage(logoImg);
         UnloadImage(logoImg);
     }
-    Image logoLImg = LoadImage("logo.png");
+    Image logoLImg = LoadImage(get_resource_path("logo_l.png")); //DONE
     Texture2D logoLTex = {0};
     if (logoLImg.data != NULL)
     {

--- a/src/rotator.c
+++ b/src/rotator.c
@@ -1,5 +1,4 @@
 #define _GNU_SOURCE
-#include "rotator.h"
 #include "astro.h"
 #include <math.h>
 #include <stdio.h>
@@ -17,6 +16,8 @@
 #include <sys/time.h>
 #include <unistd.h>
 #endif
+
+#include "rotator.h"
 
 typedef struct
 {

--- a/src/types.h
+++ b/src/types.h
@@ -7,8 +7,8 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
-//THIS SHOULD BE CHANGED!!!
-#define BUILD_FOR_DIST
+//This is toggled by make options. Only here for convinience.
+//#define BUILD_FOR_DIST
 
 // basic limits and math constants
 #define MAX_SATELLITES 15000

--- a/src/types.h
+++ b/src/types.h
@@ -7,6 +7,9 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+//THIS SHOULD BE CHANGED!!!
+#define BUILD_FOR_DIST
+
 // basic limits and math constants
 #define MAX_SATELLITES 15000
 #define MAX_MARKERS 100

--- a/src/ui.c
+++ b/src/ui.c
@@ -2,7 +2,6 @@
 #define _GNU_SOURCE
 #include "ui.h"
 #include "astro.h"
-#include "rotator.h"
 #include <ctype.h>
 #include <math.h>
 #include <raymath.h>
@@ -34,6 +33,8 @@ typedef struct tagMSG *LPMSG;
 
 #define RAYGUI_IMPLEMENTATION
 #include "../lib/raygui.h"
+
+#include "rotator.h"
 
 typedef struct
 {

--- a/src/ui.c
+++ b/src/ui.c
@@ -1017,7 +1017,7 @@ void SaveSatSelection(void)
     printf("DEBUG: %s\n", fullPath);
     snprintf(persistenceFile,sizeof(persistenceFile),fullPath);
     #else 
-    snprintf(persistenceFile, sizeof(persistenceFile),resource);
+    snprintf(persistenceFile, sizeof(persistenceFile),"persistence.bin");
     #endif
 
     FILE *f = fopen(persistenceFile, "wb");
@@ -1054,7 +1054,7 @@ void LoadSatSelection(void)
     printf("DEBUG: %s\n", fullPath);
     snprintf(persistenceFile,sizeof(persistenceFile),fullPath);
     #else 
-    snprintf(persistenceFile, sizeof(persistenceFile),resource);
+    snprintf(persistenceFile, sizeof(persistenceFile),"persistence.bin");
     #endif
 
     FILE *f = fopen(persistenceFile, "rb");

--- a/src/ui.c
+++ b/src/ui.c
@@ -407,10 +407,29 @@ static bool si_rolled_up = false;
 static Satellite *last_selected_sat = NULL;
 static Vector2 si_scroll = {0};
 
+
+
 static void LoadTLEState(AppConfig *cfg)
 {
     if (data_tle_epoch != -1) return;
-    FILE *f = fopen("data.tle", "r");
+
+    char tlefile[] = "data.tle";
+    char filename[1024];
+
+    #if defined (BUILD_FOR_DIST)
+    //The full path, with / at the end
+    char fullPath[1024];
+    const char *homeDir = getenv("XDG_CONFIG_HOME");
+    if (!homeDir) homeDir = getenv("HOME");
+    snprintf(fullPath,sizeof(fullPath),"%s/.config/TLEscope/%s", homeDir,tlefile);
+    
+    printf("DEBUG: %s\n", fullPath);
+    snprintf(filename,sizeof(filename),fullPath);
+    #else 
+    snprintf(filename, sizeof(filename),tlefile);
+    #endif
+
+    FILE *f = fopen(filename, "r");
     if (f)
     {
         char line[256];
@@ -528,7 +547,23 @@ static void *PullTLEThread(void *arg)
     (void)arg;
     AppConfig *cfg = pull_cfg;
 
-    FILE *out = fopen("data.tle", "wb");
+    char tlefile[] = "data.tle";
+    char filename[1024];
+
+    #if defined (BUILD_FOR_DIST)
+    //The full path, with / at the end
+    char fullPath[1024];
+    const char *homeDir = getenv("XDG_CONFIG_HOME");
+    if (!homeDir) homeDir = getenv("HOME");
+    snprintf(fullPath,sizeof(fullPath),"%s/.config/TLEscope/%s", homeDir,tlefile);
+    
+    printf("DEBUG: %s\n", fullPath);
+    snprintf(filename,sizeof(filename),fullPath);
+    #else 
+    snprintf(filename, sizeof(filename),tlefile);
+    #endif
+
+    FILE *out = fopen(filename, "wb");
     if (!out)
     {
         pull_state = PULL_ERROR;
@@ -970,7 +1005,22 @@ bool IsMouseOverUI(AppConfig *cfg)
 
 void SaveSatSelection(void)
 {
-    FILE *f = fopen("persistence.bin", "wb");
+    char persistenceFile[1024];
+
+    #if defined (BUILD_FOR_DIST)
+    //The full path, with /settings.json at the end
+    char fullPath[1024];
+    const char *homeDir = getenv("XDG_CONFIG_HOME");
+    if (!homeDir) homeDir = getenv("HOME");
+    snprintf(fullPath,sizeof(fullPath),"%s/.config/TLEscope/persistence.bin", homeDir);
+    
+    printf("DEBUG: %s\n", fullPath);
+    snprintf(persistenceFile,sizeof(persistenceFile),fullPath);
+    #else 
+    snprintf(persistenceFile, sizeof(persistenceFile),resource);
+    #endif
+
+    FILE *f = fopen(persistenceFile, "wb");
     if (!f)
         return;
     int count = 0;
@@ -992,7 +1042,22 @@ void SaveSatSelection(void)
 
 void LoadSatSelection(void)
 {
-    FILE *f = fopen("persistence.bin", "rb");
+    char persistenceFile[1024];
+
+    #if defined (BUILD_FOR_DIST)
+    //The full path, with /settings.json at the end
+    char fullPath[1024];
+    const char *homeDir = getenv("XDG_CONFIG_HOME");
+    if (!homeDir) homeDir = getenv("HOME");
+    snprintf(fullPath,sizeof(fullPath),"%s/.config/TLEscope/persistence.bin", homeDir);
+    
+    printf("DEBUG: %s\n", fullPath);
+    snprintf(persistenceFile,sizeof(persistenceFile),fullPath);
+    #else 
+    snprintf(persistenceFile, sizeof(persistenceFile),resource);
+    #endif
+
+    FILE *f = fopen(persistenceFile, "rb");
     if (!f)
         return;
     int count;


### PR DESCRIPTION
Now if you build with `make BUILD_FOR_DIST=yes` instead of using the resources in the current directory, they are loaded form `/usr/share/TLEscope` and user config and downloaded TLEs are saved to `.config/TLEscope`. If the config directory is not found, it is made, then populated with defaults.