### PR TITLE
Add tooltips to TLE manager copy/remove buttons

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -2493,7 +2493,8 @@ void DrawGUI(UIContext *ctx, AppConfig *cfg, Font customFont)
                         if (delim) *delim = '\0';
 
                         GuiLabel((Rectangle){viewRec.x + 10 * cfg->ui_scale + tle_mgr_scroll.x, current_y, viewRec.width - 85 * cfg->ui_scale, 24 * cfg->ui_scale}, display_name);
-                        
+                        GuiSetTooltip("Copy TLE to clipboard");
+
                         if (GuiButton((Rectangle){viewRec.x + viewRec.width - 70 * cfg->ui_scale + tle_mgr_scroll.x, current_y, 30 * cfg->ui_scale, 24 * cfg->ui_scale}, "C"))
                         {
                             char copy_buf[512];
@@ -2503,6 +2504,7 @@ void DrawGUI(UIContext *ctx, AppConfig *cfg, Font customFont)
                             }
                             SetClipboardText(copy_buf);
                         }
+                        GuiSetTooltip("Remove TLE");
 
                         if (GuiButton((Rectangle){viewRec.x + viewRec.width - 35 * cfg->ui_scale + tle_mgr_scroll.x, current_y, 30 * cfg->ui_scale, 24 * cfg->ui_scale}, "X"))
                         {


### PR DESCRIPTION
The TLE manager's C (copy) and X (remove) buttons don't explain what they do at a glance. This adds tooltips to both buttons using raygui's GuiSetTooltip, so hovering shows "Copy TLE to clipboard" on C and "Remove TLE" on X.

No new dependencies, purely a UI affordance improvement.

Fixes #32